### PR TITLE
Feature/US-FIX-JWTBearerEvents

### DIFF
--- a/ong-red-project/OngProject/Startup.cs
+++ b/ong-red-project/OngProject/Startup.cs
@@ -70,7 +70,6 @@ namespace OngProject
 
             // JWT Token Generator
 
-
             #region JWT Token Generator
 
             services.Configure<JWTSettings>(Configuration.GetSection("JWTSettings"));
@@ -97,20 +96,35 @@ namespace OngProject
 
                 options.Events = new JwtBearerEvents()
                 {
-                    OnAuthenticationFailed = c =>
+                    OnAuthenticationFailed = context =>
                     {
-                        c.NoResult();
-                        c.Response.StatusCode = 500;
-                        c.Response.ContentType = "text/plain";
-                        return c.Response.WriteAsync(c.Exception.ToString());
+                        context.NoResult();
+                        context.Response.StatusCode = 500;
+                        context.Response.ContentType = "application/json";
+
+                        string response = JsonConvert.SerializeObject(new Result().Fail("El token de acceso proporcionado no es válido."));
+                        if (context.Exception.GetType() == typeof(SecurityTokenExpiredException))
+                        {
+                            context.Response.Headers.Add("Token-Expired", "true");
+                            response = JsonConvert.SerializeObject(new Result().Fail("El token de acceso proporcionado ha expirado."));
+                        }
+
+                        return context.Response.WriteAsync(response);
                     },
                     OnChallenge = context =>
                     {
-                        context.HandleResponse();
-                        context.Response.StatusCode = 401;
-                        context.Response.ContentType = "application/json";
-                        var result = JsonConvert.SerializeObject(new Result().Fail("Usted no esta autorizado."));
-                        return context.Response.WriteAsync(result);
+                        try
+                        {
+                            context.HandleResponse();
+                            context.Response.StatusCode = 401;
+                            context.Response.ContentType = "application/json";
+                            var result = JsonConvert.SerializeObject(new Result().Fail("Usted no esta autorizado."));
+                            return context.Response.WriteAsync(result);
+                        }
+                        catch (Exception ex)
+                        {
+                            return context.Response.WriteAsync("");
+                        }
                     },
                     OnForbidden = context =>
                     {
@@ -123,7 +137,6 @@ namespace OngProject
             });
 
             #endregion JWT Token Generator
-
 
             //AWS S3 Configuration
             services.AddAWSService<IAmazonS3>(Configuration.GetAWSOptions());


### PR DESCRIPTION
### Resumen

-  Se soluciono el problema de la respuesta del _JwtBearerEvents_, que al enviar un token invalido o expirado lanzaba una excepción no controlada, se agregaron respuestas personalizadas para ambos casos.


**Respuesta satisfactoria**

![ok](https://user-images.githubusercontent.com/88169605/146832435-c7c2a97b-a519-4396-b8d6-b970d8afddd4.png)


**Token Expirado**

![expirado](https://user-images.githubusercontent.com/88169605/146832469-3b0aa0a7-0584-495b-b976-4fee26fd7f16.png)


**Token Invalido** Al agregar o quitar valores del cuerpo del token

![invalido](https://user-images.githubusercontent.com/88169605/146832510-a3817bf7-ae88-4d30-b29e-c5ddbbc2fb68.png)

