### PR TITLE
US-27# Visualizar todos los nombres de categorias con paginacion como administrador.

### DIFF
--- a/ong-red-project/OngProject/Controllers/CategoryController.cs
+++ b/ong-red-project/OngProject/Controllers/CategoryController.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
+using System.Security.Claims;
 namespace OngProject.Controllers
 {
     [Route("[controller]")]
@@ -31,6 +31,27 @@ namespace OngProject.Controllers
                 ? BadRequest(request.Messages)
                 : Ok(request);
         }
-
+        
+        /// <summary>
+        /// Endpoint para obtener los nombres de categorias por pagina como administrador
+        /// </summary>
+        /// <response code="200">Lista de a 10 categorias paginada.</response>
+        /// <response code="404">No se encuentran categorias</response>
+        /// <response code="401">Credenciales no validas</response> 
+        [Authorize(Roles = "Administrator")]
+        [HttpGet]
+        public async Task<ActionResult> GetCategories([FromQuery]int page){
+            var categories = await _CategoriesServices.GetCategories(page);
+            if(categories.Length > 0){
+                return StatusCode(200, categories);
+            }
+            return StatusCode(404, new
+            {
+                Messages = new string[]{
+                    String.Format("No se encuentran categorias en la pagina {0}",page)
+                },
+                HasErrors = false
+            });
+        }
     }
 }

--- a/ong-red-project/OngProject/Core/Interfaces/IServices/ICategoriesServices.cs
+++ b/ong-red-project/OngProject/Core/Interfaces/IServices/ICategoriesServices.cs
@@ -1,4 +1,5 @@
 ﻿using OngProject.Common;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace OngProject.Core.Interfaces.IServices
@@ -6,5 +7,6 @@ namespace OngProject.Core.Interfaces.IServices
     public interface ICategoriesServices
     {
         Task<Result> Delete(int id);
+        Task<string[]> GetCategories(int page);
     }
 }

--- a/ong-red-project/OngProject/Core/Services/CategoriesServices.cs
+++ b/ong-red-project/OngProject/Core/Services/CategoriesServices.cs
@@ -48,9 +48,11 @@ namespace OngProject.Core.Services
             return new Result().Fail("Ocurrio un error al eliminar el testimonial");
         }
 
-      
-        
-
-       
+        public async Task<string[]> GetCategories(int page)
+        {
+            return
+            (await _unitOfWork.CategoryRepository.GetPageAsync(c => c, 10, page))
+            .Select(c => c.Name).ToArray();
+        }
     }
 }

--- a/ong-red-project/OngProject/Core/Services/UserServices.cs
+++ b/ong-red-project/OngProject/Core/Services/UserServices.cs
@@ -109,7 +109,7 @@ namespace OngProject.Core.Services
             {
                 new Claim(JwtRegisteredClaimNames.NameId, user.Id.ToString()),
                 new Claim(JwtRegisteredClaimNames.Email, user.Email),
-                new Claim("Role", user.Role.Name),
+                new Claim(ClaimTypes.Role, user.Role.Name),
                 new Claim("Password", user.Password),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             };


### PR DESCRIPTION
- Se pueden ver las categorias paginadas cada 10 elementos - por un administrador
- Se corrigio UserService para que el sistema pueda reconocer los roles.

Login - prueba administrador:
![Captura de pantalla de 2021-12-22 15-21-42](https://user-images.githubusercontent.com/38444032/147138080-b0472d4c-0a12-4639-aa99-5522492c0e33.png)

![Captura de pantalla de 2021-12-22 15-23-55](https://user-images.githubusercontent.com/38444032/147138209-77e7523b-9248-48c1-beb7-48565302160a.png)

Categorias no encontradas:
![Captura de pantalla de 2021-12-22 15-24-35](https://user-images.githubusercontent.com/38444032/147138285-a3c35892-e714-4bac-bec5-bd28817fb739.png)

Token invalido - no autenticado:
![Captura de pantalla de 2021-12-22 15-25-32](https://user-images.githubusercontent.com/38444032/147138375-09308795-9191-4f20-92a4-9914e7152e49.png)



