### PR TITLE
Feature/us 62

### DIFF
--- a/ong-red-project/OngProject/Controllers/NewsController.cs
+++ b/ong-red-project/OngProject/Controllers/NewsController.cs
@@ -18,6 +18,26 @@ namespace OngProject.Controllers
         {
             _newsServices = newsServices;
         }
-        
+
+
+        #region Documentacion
+        /// <summary>
+        /// Endpoint para listar los comentarios pertenecientes a un post. 
+        /// </summary>
+        /// <response code="200">Listado de todos los comentarios pertenecientes a un post .</response>
+        /// <response code="401">Credenciales inválidas.</response> 
+        /// <response code="404">No se ha encontrado el dato proporcionado.</response>
+        #endregion
+        [Authorize]
+        [HttpGet("{id}/comments")]
+        public async Task<ActionResult> GetAllCommentsByNews(int id)
+        {
+            var result = await _newsServices.GetAllCommentsByNews(id);
+            if (result == null)
+                return NotFound("No existe el post");
+            return Ok(result);
+        }
+
+
     }
 }

--- a/ong-red-project/OngProject/Core/Interfaces/IServices/INewsServices.cs
+++ b/ong-red-project/OngProject/Core/Interfaces/IServices/INewsServices.cs
@@ -11,5 +11,6 @@ namespace OngProject.Core.Interfaces.IServices
     public interface INewsServices
     {
         Task<bool> NewsExistsById(int id);
+        Task<Comments[]> GetAllCommentsByNews(int id);
     }
 }

--- a/ong-red-project/OngProject/Core/Services/NewsServices.cs
+++ b/ong-red-project/OngProject/Core/Services/NewsServices.cs
@@ -34,5 +34,15 @@ namespace OngProject.Core.Services
                 return true;
             return false;
         }
+
+        public async Task<Comments[]> GetAllCommentsByNews(int id)
+        {
+            var news = _unitOfWork.NewsRepository.EntityExists(id);
+            if (!news)
+                return null;
+
+            return (await _unitOfWork.CommentsRepository.GetAll())
+                .Where(n => n.NewId == id).ToArray();
+        }
     }
 }


### PR DESCRIPTION
## Resumen:

- Agregado controlador para obtener los comentarios con el id de un post(news) siendo la ruta **News/:id/comments**
- Agregado task en interface de news
- Verificación de post(news) existente obtenido en el query
- Verificación de comentarios correspondientes con el id proporcionado y mostrando solo los que cumplan la condición

### Intento de búsqueda de Id Post inexistente:
![post-doesnt-exists](https://user-images.githubusercontent.com/81714676/147362801-32b677c2-b200-43a8-a74c-881c1351cf63.PNG)


### Búsqueda de comentarios de acuerdo al post Id 2:
![comments-list](https://user-images.githubusercontent.com/81714676/147362857-75f9315a-ee3b-4c2d-a524-341c7c9d2f4c.PNG)


### Database:
![database](https://user-images.githubusercontent.com/81714676/147362867-b4f49421-3b16-42a0-9067-8071e3caf690.PNG)
