### PR TITLE
post slide y clase slidedto creados

### DIFF
--- a/ong-red-project/OngProject/Controllers/SlidesController.cs
+++ b/ong-red-project/OngProject/Controllers/SlidesController.cs
@@ -59,5 +59,22 @@ namespace OngProject.Controllers
             }
         }
 
+        #region Documentation
+        /// <summary>
+        /// Crea nueva slide, devuelve su ID en caso de exito.
+        /// </summary>
+        /// <response code="201">Solicitud concretada con exito</response>
+        /// <response code="400">Errores de validacion.</response>
+        /// <response code="403">Credenciales invalidas</response>  
+        #endregion
+        [HttpPost]
+        [Authorize(Roles="Administrator")]
+        public async Task<IActionResult> CreateSlide(SlideDTO model){
+            if(!ModelState.IsValid){
+                return BadRequest();
+            }
+            return Ok(await _slidesServices.CreateSlideAsync(model));
+        }
+
     }
 }

--- a/ong-red-project/OngProject/Core/DTOs/SlidesDTOs/SlideDTO.cs
+++ b/ong-red-project/OngProject/Core/DTOs/SlidesDTOs/SlideDTO.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OngProject.Core.DTOs.SlidesDTOs
+{
+    public class SlideDTO
+    {
+        [Required]
+        [Column(TypeName = "VARCHAR(4000)")]
+        [MaxLength(4000)]
+        public string Text { get; set; }
+
+        [Column(TypeName = "INTEGER")]
+        public int? Order { get; set; }
+
+        [DataType(DataType.DateTime)]
+        public DateTime CreatedAt { get; set; } = new DateTime(); 
+
+        public string Base64Image { get; set; }
+        
+        [Required]
+        public int? OrganizationId { get; set; } = null;
+
+    }
+}

--- a/ong-red-project/OngProject/Core/Helper/Base64ImageExplorer/Base64ImageInspector.cs
+++ b/ong-red-project/OngProject/Core/Helper/Base64ImageExplorer/Base64ImageInspector.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OngProject.Core.Helper.Base64ImageInspector
+{
+    public class Base64ImageInspector
+    {
+        public static void SplitIntoTypeAndImageData(string encodedImage, out string contentType ,out string imageType, out string content)
+        {
+            contentType = "";
+            imageType = "";
+            content = encodedImage;
+            if(!string.IsNullOrEmpty(encodedImage) && encodedImage.StartsWith("data:") )
+            {
+                int indexOfFirstComma = encodedImage.IndexOf(',');
+                if(indexOfFirstComma + 1 < encodedImage.Length || indexOfFirstComma >= 0)
+                {
+                    GetTypeInfo(encodedImage, indexOfFirstComma, out contentType, out imageType);
+                    content = encodedImage.Substring(indexOfFirstComma + 1); 
+                }
+            }
+        }
+
+        private static void GetTypeInfo(string encodedImage, int indexOfFirstComma, out string contentType, out string imageType)
+        {
+            string header = encodedImage.Substring(0,indexOfFirstComma);
+            if(header.Contains("image/jpg"))
+            {
+                contentType = "image/jpg";
+                imageType = "jpg";
+            }
+
+            if(header.Contains("image/png"))
+            {
+                contentType = "image/png";
+                imageType = "png";
+            }
+            if(header.Contains("image/jpeg"))
+            {
+                contentType = "image/jpeg";
+                imageType = "jpeg";
+            }
+            else    
+            {
+                contentType = "";
+                imageType = "";
+            }
+        }
+    }
+}

--- a/ong-red-project/OngProject/Core/Interfaces/IServices/ISlidesServices.cs
+++ b/ong-red-project/OngProject/Core/Interfaces/IServices/ISlidesServices.cs
@@ -11,6 +11,7 @@ namespace OngProject.Core.Interfaces.IServices
         bool EntityExist(int id);
         Task<List<SlideDataShortResponse> > GetListOfSlides();
         Task<SlideDataFullResponse> GetSlideById(int id);
+        Task<int> CreateSlideAsync(SlideDTO model);
     }
 
 }

--- a/ong-red-project/OngProject/Core/Mapper/EntityMapper.cs
+++ b/ong-red-project/OngProject/Core/Mapper/EntityMapper.cs
@@ -263,7 +263,19 @@ namespace OngProject.Core.Mapper
             return result;
         }
 
+        public Slides FromEntryDTOtoSlide(SlideDTO model)
+        {
+            return new Slides(){
+                Text = model.Text,
+                Order = (int) model.Order,
+                OrganizationId = (int) model.OrganizationId,               
+                CreatedAt = model.CreatedAt,
+                IsDeleted = false
+            };
+        }
+
         #endregion Slides Mappers
 
     }
 }
+

--- a/ong-red-project/OngProject/Core/Services/SlidesServices.cs
+++ b/ong-red-project/OngProject/Core/Services/SlidesServices.cs
@@ -3,6 +3,7 @@ using OngProject.Common;
 using OngProject.Core.DTOs;
 using OngProject.Core.DTOs.SlidesDTOs;
 using OngProject.Core.Entities;
+using OngProject.Core.Helper.Base64ImageInspector;
 using OngProject.Core.Helper.FomFileData;
 using OngProject.Core.Helper.S3;
 using OngProject.Core.Interfaces.IServices;
@@ -32,13 +33,10 @@ namespace OngProject.Core.Services
         } 
         #endregion
 
-
         public bool EntityExist(int id)
         {
             return _unitOfWork.SlidesRepository.EntityExists(id);
-        }
-        
-        
+        }        
 
         public async Task<List<SlideDataShortResponse>> GetListOfSlides()
         {
@@ -57,6 +55,50 @@ namespace OngProject.Core.Services
             return _mapper.FromSlideToSlidesFullResponseDTO(slide);
         }
 
+        public async Task<int> CreateSlideAsync(SlideDTO model)
+        {
+            if(model.Order ==null)
+                await SetOrderAsTheLastExistentAsync(model);
 
+            Slides slide = _mapper.FromEntryDTOtoSlide(model);
+
+            Result resultFromAws = await UploadEncodedImageToBucketAsync(model.Base64Image);
+            
+            if(resultFromAws.HasErrors == false)
+                slide.ImageUrl = resultFromAws.Messages[0];    
+
+            await _unitOfWork.SlidesRepository.Insert(slide);
+            await _unitOfWork.SaveChangesAsync();
+            return slide.Id;
+        }
+
+        private string GetNewImageName(string imageType)
+        {
+            TimeSpan elapsedTime = DateTime.Now - DateTime.UnixEpoch;
+            var timestamp = (long) elapsedTime.TotalSeconds;
+            return "slide_" + timestamp + '.' + imageType;
+        }
+
+        private async Task<Result> UploadEncodedImageToBucketAsync(string rawBase64File) 
+        {
+            Base64ImageInspector.SplitIntoTypeAndImageData(rawBase64File, out string contentType, out string imageType, out string base64ImageData);
+            string newName = GetNewImageName(imageType);
+            var formFileData = new FormFileData(){
+                FileName = newName,
+                ContentType = contentType,
+                Name = newName
+            };
+            byte[] imageBinaryFile = Convert.FromBase64String(base64ImageData);
+            IFormFile newFile = ConvertFile.BinaryToFormFile(imageBinaryFile, formFileData);
+            return await _imageServices.Save(newFile.FileName, newFile);
+        }
+        
+        private async Task SetOrderAsTheLastExistentAsync(SlideDTO model)
+        {
+            IEnumerable<Slides> slides = await _unitOfWork.SlidesRepository.GetAll();
+            var maxOrder = slides.Select(s => s.Order).Max();
+            model.Order = maxOrder + 1;
+        }
+  
     }
 }


### PR DESCRIPTION
1. Método Post para crear slides creado
2. Clase SlidesDto para recibir data de usuario creada
3. Interfaz servicios de slides actualizada
4. Servicio crear slide añadido junto a helpers de clase
5. Clase mapper actualizada para nuevo slidedto
6. Helper para inspeccionar imágenes base64 creado

**Nota** Asumo que si se provee Id de organización (fk de slide) este existe en tabla organización, sin considerar que sucede en otro caso.

### Administrador crea slide con id válido de organizacion, obteniendo id de nuevo slide
![admin-creates-slide-with-valid-organization-id](https://user-images.githubusercontent.com/21247165/147797145-d991a58b-e8ec-4024-899f-48fc3c9c87fc.png)

### Administrador intenta crear slide con datos incompletos
![admin-try-create-slide-without-organization-id](https://user-images.githubusercontent.com/21247165/147797181-16f3334d-1540-4fdf-8408-a3c18843b303.png)

### Usuario regular intentando crear slide 
![regular-user-try-post-slide](https://user-images.githubusercontent.com/21247165/147797225-88966044-882b-4971-9801-9c7ae0e887e6.png)

### Administrador crea slide sin orden, asignándosele el del máximo existente + 1 
![admin-creates-slide-without-order](https://user-images.githubusercontent.com/21247165/147798036-4505484f-5327-446f-ad40-47f39c4afd9d.png)

