### PR TITLE
correccion metodo que retorna el tipo de imagen

### DIFF
--- a/ong-red-project/OngProject/Core/Helper/Base64ImageExplorer/Base64ImageInspector.cs
+++ b/ong-red-project/OngProject/Core/Helper/Base64ImageExplorer/Base64ImageInspector.cs
@@ -30,14 +30,11 @@ namespace OngProject.Core.Helper.Base64ImageInspector
             {
                 contentType = "image/jpg";
                 imageType = "jpg";
-            }
-
-            if(header.Contains("image/png"))
+            }else if(header.Contains("image/png"))
             {
                 contentType = "image/png";
                 imageType = "png";
-            }
-            if(header.Contains("image/jpeg"))
+            }else if(header.Contains("image/jpeg"))
             {
                 contentType = "image/jpeg";
                 imageType = "jpeg";


### PR DESCRIPTION
- Corrijo método que obtiene tipo de la imagen codificada pues antes solo funcionaba con tipos jpeg.