### PR TITLE
Feature/us 65

### DIFF
--- a/ong-red-project/OngProject/Controllers/MemberController.cs
+++ b/ong-red-project/OngProject/Controllers/MemberController.cs
@@ -38,18 +38,20 @@ namespace OngProject.Controllers
 
         [Authorize]
         [HttpGet]
-        public async Task<IActionResult> GetAll([FromQuery]int page = 1)
+        public async Task<IActionResult> GetAll([FromQuery]int? page)
         {
             try
             {
                 if (User.IsInRole("Administrator"))
                     return Ok(await _memberServices.GetAllAsync());
+                if (!page.HasValue)
+                    return BadRequest(new Result().Fail("No existe la página proporcionada."));
 
-                return Ok(await _memberServices.GetAllByPaginationAsync(page));
+                return Ok(await _memberServices.GetAllByPaginationAsync((int)page));
             }
             catch (Exception e)
             {
-                return NotFound(new Result().NotFound());
+                return BadRequest(new Result().Fail(e.Message));
             }
         }
 

--- a/ong-red-project/OngProject/Controllers/MemberController.cs
+++ b/ong-red-project/OngProject/Controllers/MemberController.cs
@@ -36,17 +36,20 @@ namespace OngProject.Controllers
 
         #endregion Documentation
 
-        [Authorize(Roles = "Administrator")]
+        [Authorize]
         [HttpGet]
-        public async Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll([FromQuery]int page = 1)
         {
             try
             {
-                return Ok(await _memberServices.GetAllAsync());
+                if (User.IsInRole("Administrator"))
+                    return Ok(await _memberServices.GetAllAsync());
+
+                return Ok(await _memberServices.GetAllByPaginationAsync(page));
             }
             catch (Exception e)
             {
-                return NotFound(e.Message);
+                return NotFound(new Result().NotFound());
             }
         }
 

--- a/ong-red-project/OngProject/Controllers/MemberController.cs
+++ b/ong-red-project/OngProject/Controllers/MemberController.cs
@@ -45,7 +45,7 @@ namespace OngProject.Controllers
                 if (User.IsInRole("Administrator"))
                     return Ok(await _memberServices.GetAllAsync());
                 if (!page.HasValue)
-                    return BadRequest(new Result().Fail("No existe la página proporcionada."));
+                    return Unauthorized("Usted no esta autorizado.");
 
                 return Ok(await _memberServices.GetAllByPaginationAsync((int)page));
             }

--- a/ong-red-project/OngProject/Core/Interfaces/IServices/IMemberServices.cs
+++ b/ong-red-project/OngProject/Core/Interfaces/IServices/IMemberServices.cs
@@ -1,5 +1,6 @@
 ﻿using OngProject.Common;
 using OngProject.Core.DTOs;
+using OngProject.Core.Helper.Pagination;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,6 +9,7 @@ namespace OngProject.Core.Interfaces.IServices
     public interface IMemberServices
     {
         Task<List<MembersDTO>> GetAllAsync();
+        Task<PaginationDTO<MembersDTO>> GetAllByPaginationAsync(int page);
 
         Task<Result> CreateAsync(MemberInsertDTO newMember);
 

--- a/ong-red-project/OngProject/Core/Services/MemberServices.cs
+++ b/ong-red-project/OngProject/Core/Services/MemberServices.cs
@@ -75,7 +75,7 @@ namespace OngProject.Core.Services
 
         public async Task<PaginationDTO<MembersDTO>> GetAllByPaginationAsync(int page)
         {
-            var quantity = 10;
+            int quantity = 10;
             var prevPage = string.Empty;
             var nextPage = string.Empty;
             var membersCount = await _unitOfWork.MemberRepository.CountAsync();
@@ -86,10 +86,10 @@ namespace OngProject.Core.Services
             if (page > totalPages || page == 1)
                 page = 1;
             else
-                prevPage = _uriService.GetPage("/Members", page - 1);
+                prevPage = _uriService.GetPage("/Member", page - 1);
 
             if (page < totalPages)
-                nextPage = _uriService.GetPage("/Members", page + 1);
+                nextPage = _uriService.GetPage("/Member", page + 1);
 
 
             var membersList = await _unitOfWork.MemberRepository.GetPageAsync(x => x.Id > 0, quantity, page);

--- a/ong-red-project/OngProject/Core/Services/MemberServices.cs
+++ b/ong-red-project/OngProject/Core/Services/MemberServices.cs
@@ -66,7 +66,7 @@ namespace OngProject.Core.Services
             var members = await _unitOfWork.MemberRepository.GetAll();
 
             if (!members.Any())
-                throw new Exception();
+                throw new Exception("No hay datos a mostrar.");
 
             var membersDto = members.Select(m => _mapper.FromMembersToMembersDto(m)).ToList();
 
@@ -83,8 +83,8 @@ namespace OngProject.Core.Services
             if ((membersCount % quantity) > 0)
                 totalPages++;
 
-            if (page > totalPages || page == 1)
-                page = 1;
+            if (page > totalPages)
+                throw new Exception("No existe la página proporcionada.");
             else
                 prevPage = _uriService.GetPage("/Member", page - 1);
 


### PR DESCRIPTION
## Resumen:

- Ya existe un método GetAll de todos los Members, ahora se verifica el rol para mostrar la lista de acuerdo al rol de usuario.
- Creado el Task PaginationDTO en la interface de Members.
- Agregada implementación de paginación para Members con respuesta PaginationDTO<MembersDTO>.
- Para usuario Standard si no envía una página, entonces por default devuelve los primeros 10 Members.
- Para usuario Standard si envía una página inexistente, entonces por default devuelve los primeros 10 Members.

### Base de datos de Members
![db_members](https://user-images.githubusercontent.com/81714676/148424882-9f147ae9-774e-458b-8fda-9e5a191ee962.PNG)

## Login de Administrator :
![login_admin](https://user-images.githubusercontent.com/81714676/148423875-6781a634-9633-49fe-a1ab-9adc7b58e83b.PNG)

### Petición Get con Administrator devuelve todos los Members
![get_admin](https://user-images.githubusercontent.com/81714676/148424104-02c07f88-473f-4073-9197-ee47e156b51f.PNG)

### Login de usuario Standard
![login_standard](https://user-images.githubusercontent.com/81714676/148424243-694c836a-8f11-45b6-abb2-0d0ac6d682be.PNG)

### Obtención de Members sin enviar el parámetro Page siendo Usuario Standard:
![no_exists_page](https://user-images.githubusercontent.com/81714676/148433987-a55979db-453d-4e7e-bd48-8f6701a19049.PNG)

### Obtención de Members enviando Page 2:
![page_2](https://user-images.githubusercontent.com/81714676/148425555-aa94028d-13ae-40c8-9d7d-784180880cad.PNG)

### Obtención de Members enviando Page inexistente:
![page_limit_no_exists](https://user-images.githubusercontent.com/81714676/148433298-d8cac8ea-975a-47c8-a5f7-53f588571107.PNG)

