### PR TITLE
Feature/us 76

### DIFF
--- a/ong-red-project/Test/UnitTest/MemberControllerTest/CreateMemberEndpointTest.cs
+++ b/ong-red-project/Test/UnitTest/MemberControllerTest/CreateMemberEndpointTest.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using OngProject.Common;
+using OngProject.Controllers;
+using OngProject.Core.DTOs;
+using OngProject.Infrastructure.Data;
+using Xunit;
+
+namespace Test.UnitTest.MemberTest
+{
+    public class CreateMemberEndpointTests
+    {
+        private ApplicationDbContext _stubContext;
+        private FakeMemberService _stubService;
+        private MemberInsertDTO _validMember;
+        private MemberInsertDTO _invalidImageMember;
+        private MemberInsertDTO _invalidMember;
+
+        public CreateMemberEndpointTests()
+        {
+            _stubContext = FakeDbContext.GetContext();
+            _stubService = new FakeMemberService(_stubContext);
+            _validMember = new MemberInsertDTO()
+            {
+                Name = "Emma",
+                Image = new FormFile(new MemoryStream(), 0, 100, "validImage", "validImage.png")
+            };  
+
+            _invalidImageMember = new MemberInsertDTO()
+            {
+                Name = "Emma",
+                Image = new FormFile(new MemoryStream(), 0, 100, "invalidImage", "invalidImage.pdf")
+            };  
+
+            _invalidMember = new MemberInsertDTO()
+            {
+                Image = new FormFile(new MemoryStream(), 0, 100, "validImage", "validImage.png")
+            };  
+        }
+
+        [Fact(DisplayName= "Create valid Member should return Ok and update database")]
+        public async Task CreateMemberWithValidDataShouldReturnOkAndUpdateBase()
+        {
+            var controller = new MemberController(_stubService);
+            MemberInsertDTO validMember = _validMember;
+
+            var createdResponse = await controller.Create(validMember);
+
+            Assert.IsType<OkObjectResult>(createdResponse);
+            var result = createdResponse as OkObjectResult;
+            Assert.NotNull(result);
+            Result response = result.Value as Result;
+            Assert.NotNull(response);
+            var responseMessage = response.Messages[0];
+            Assert.Equal("Datos guardados satisfactoriamente.", responseMessage);
+        }
+        
+        [Fact(DisplayName= "Create Member with invalid image should return BadResult and no update database")]
+        public async Task CreateMemberWithInvalidImageShouldFail()
+        {
+            var controller = new MemberController(_stubService);
+            MemberInsertDTO newMember = _invalidImageMember;
+
+            var createdResponse = await controller.Create(newMember);
+
+            Assert.IsType<BadRequestObjectResult>(createdResponse);
+            var result = createdResponse as BadRequestObjectResult;
+            Assert.NotNull(result);
+            Result response = result.Value as Result;
+            Assert.NotNull(response);
+            var responseMessage = response.Messages[0];
+            Assert.Equal("Ocurrio un error al momento de intentar ingresar los datos - extension no valida", responseMessage);
+        }
+        
+        [Fact(DisplayName= "Create Member with invalid data should return BadResult and no update database")]
+        public async Task CreateInvalidMemberShouldReturnBadRequestWithoutUpdateDatabase()
+        {
+            var controller = new MemberController(_stubService);
+            MemberInsertDTO noNameMember = _invalidMember;
+            controller.ModelState.AddModelError("Name","Required");
+            
+            var createdResponse = await controller.Create(noNameMember);
+
+            Assert.IsType<BadRequestObjectResult>(createdResponse);
+            var result = createdResponse as BadRequestObjectResult;
+            Assert.NotNull(result);
+            Result response = result.Value as Result;
+            Assert.NotNull(response);
+            var responseMessage = response.Messages[0];
+            Assert.Equal("Algo salio mal.", responseMessage);
+        }
+    }
+}

--- a/ong-red-project/Test/UnitTest/MemberControllerTest/FakeDbContext.cs
+++ b/ong-red-project/Test/UnitTest/MemberControllerTest/FakeDbContext.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using OngProject.Infrastructure.Data;
+
+namespace Test.UnitTest.MemberTest
+{
+    public class FakeDbContext
+    {
+        public static ApplicationDbContext GetContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                                .Options;
+            var context = new ApplicationDbContext(options);
+
+            return context;
+        }
+
+
+    }
+}

--- a/ong-red-project/Test/UnitTest/MemberControllerTest/FakeMemberService.cs
+++ b/ong-red-project/Test/UnitTest/MemberControllerTest/FakeMemberService.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OngProject.Common;
+using OngProject.Core.DTOs;
+using OngProject.Core.Entities;
+using OngProject.Core.Helper.Pagination;
+using OngProject.Core.Interfaces.IServices;
+using OngProject.Infrastructure.Data;
+
+namespace Test.UnitTest.MemberTest
+{
+    public class FakeMemberService : IMemberServices
+    {
+        private ApplicationDbContext _dbContext;
+        public FakeMemberService(ApplicationDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task<Result> CreateAsync(MemberInsertDTO newMember)
+        {
+            var newRecord = new Member
+            {
+                Name = newMember.Name,
+                FacebookUrl = newMember.FacebookUrl,
+                InstagramUrl = newMember.InstagramUrl,
+                LinkedinUrl = newMember.LinkedinUrl,
+                Description = newMember.Description
+            };
+
+            var isPng = newMember.Image.FileName.EndsWith(".png");
+            if(isPng)
+            {
+                await _dbContext.Members.AddAsync(newRecord);
+                await _dbContext.SaveChangesAsync();
+                return new Result().Success("Datos guardados satisfactoriamente.");
+            }
+            throw new Exception("extension no valida");
+        }
+
+        public Task<ResultValue<List<MembersDTO>>> GetAllAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<ResultValue<PaginationDTO<MembersDTO>>> GetAllByPaginationAsync(int page)
+        {
+            List<MembersDTO> x = new List<MembersDTO>{null, null, null, null, null, null, null};
+
+            var newPage = new PaginationDTO<MembersDTO>()
+            {
+                Items = x
+            };
+            await Task.Delay(10);
+            if(page == 1)
+            {
+                return new ResultValue<PaginationDTO<MembersDTO>>()
+                {
+                    StatusCode = 200,
+                    Value = newPage
+                };
+            }
+            
+            return new ResultValue<PaginationDTO<MembersDTO>>() {
+                StatusCode = 400, 
+                Messages = new List<string>() { "No existe la página proporcionada." } 
+            };
+        }
+
+        public Task<Result> UpdateAsync(MemberUpdateDTO memberUpdate)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/ong-red-project/Test/UnitTest/MemberControllerTest/GetMembersEndpointTests.cs
+++ b/ong-red-project/Test/UnitTest/MemberControllerTest/GetMembersEndpointTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using OngProject.Common;
+using OngProject.Controllers;
+using OngProject.Core.DTOs;
+using OngProject.Core.Helper.Pagination;
+using OngProject.Infrastructure.Data;
+using Xunit;
+
+namespace Test.UnitTest.MemberTest
+{
+    public class GetMembersEndpointTests
+    {
+        private MemberController _controller;
+        private ApplicationDbContext _stubContext;
+        private FakeMemberService _stubService;
+        public GetMembersEndpointTests()
+        {
+            _stubContext = FakeDbContext.GetContext();
+            _stubService = new FakeMemberService(_stubContext);
+            _controller = new MemberController(_stubService);
+            var regularUser = new ClaimsPrincipal(new ClaimsIdentity()); 
+            _controller.ControllerContext = new ControllerContext(); 
+            _controller.ControllerContext.HttpContext = new DefaultHttpContext { User = regularUser }; 
+        }
+
+        [Fact(DisplayName ="Get Members by valid page number returns status code 200 and required members")]        
+        public async Task GetAllMembersWithValidPageReturnsStatus200AndMembers()
+        {
+            var pageOne = 1;
+
+            var createdResponse = await _controller.GetAll(pageOne);
+
+            Assert.IsType<ObjectResult>(createdResponse);
+            var result = createdResponse as ObjectResult;
+            Assert.NotNull(result);
+            var response = result.Value as ResultValue<PaginationDTO<MembersDTO>>;
+            Assert.NotNull(response);
+            var resultStatusCode = response.StatusCode;
+            Assert.Equal(200, resultStatusCode);
+            PaginationDTO<MembersDTO> responsePage = response.Value;
+            List<MembersDTO> membersList = responsePage.Items;
+            Assert.Equal(7, membersList.Count);
+        }
+
+        [Fact(DisplayName ="Get Members by inexistent page returns status code 400")]
+        public async Task GetMembersByInexistentPageReturnsStatus400()
+        {
+            var pageTen = 10;
+
+            var createdResponse = await _controller.GetAll(pageTen);
+
+            Assert.IsType<ObjectResult>(createdResponse);
+            var result = createdResponse as ObjectResult;
+            Assert.NotNull(result);
+            var response = result.Value as ResultValue<PaginationDTO<MembersDTO>>;
+            Assert.NotNull(response);
+            var resultStatusCode = response.StatusCode;
+            Assert.Equal(400, resultStatusCode);
+            string responseMessage = response.Messages[0];
+            Assert.Equal("No existe la página proporcionada.", responseMessage);
+        }
+
+        [Fact(DisplayName ="Get Members with no page number returns status code 403")]
+        public async Task GetMembersWithNoPageReturnsStatus403()
+        {
+            int? nullPage = null;
+
+            var createdResponse = await _controller.GetAll(nullPage);
+                
+            Assert.IsType<ObjectResult>(createdResponse);
+            var result = createdResponse as ObjectResult;
+            Assert.NotNull(result);
+            var resultStatusCode = result.StatusCode;
+            Assert.Equal(403, resultStatusCode);
+        }
+    }
+}
+

--- a/ong-red-project/Test/UnitTest/MemberControllerTest/UpdateMemberEndpointTests.cs
+++ b/ong-red-project/Test/UnitTest/MemberControllerTest/UpdateMemberEndpointTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using OngProject.Common;
+using OngProject.Controllers;
+using OngProject.Core.DTOs;
+using OngProject.Core.Interfaces.IServices;
+using Xunit;
+
+namespace Test.UnitTest.MemberTest
+{
+    public class UpdateMemberEndpointTests
+    {
+        private Mock<IMemberServices> _mock;
+        private MemberUpdateDTO _validMember;
+        private MemberUpdateDTO _memberWithId100;
+        private MemberUpdateDTO _memberWithoutName;
+        
+        public UpdateMemberEndpointTests()
+        {
+            _mock = new Mock<IMemberServices>();
+            _validMember = new MemberUpdateDTO()
+            {
+                Id = 1,
+                Name = "jose",
+            };
+
+            _memberWithoutName = new MemberUpdateDTO()
+            {
+                Id = 1,
+            };
+
+            _memberWithId100 = new MemberUpdateDTO()
+            {
+                Id = 100,
+                Name = "jose",
+            };
+
+        }
+        [Fact(DisplayName ="Update valid member should return Ok")]
+        public async Task UpdateMemberWithValidIdShouldReturnOk()
+        {
+            _mock.Setup(m => m.UpdateAsync(_validMember)).ReturnsAsync(new Result().Success("Miembro actualizado con éxito.")); 
+            var controller = new MemberController(_mock.Object);
+
+            var createdResponse = await controller.Update(_validMember, 1);
+
+            Assert.IsType<OkObjectResult>(createdResponse);
+            var result = createdResponse as OkObjectResult;
+            Assert.NotNull(result);
+            Result response = result.Value as Result;
+            Assert.NotNull(response);
+            var responseMessage = response.Messages[0];
+            Assert.Equal("Miembro actualizado con éxito.", responseMessage);
+        }
+
+        [Fact(DisplayName = "Update member with invalid Id should return BadRequest")]
+        public async Task UpdateMemberWithInvalidIdShouldReturnBadRequest()
+        {
+            _mock.Setup(m => m.UpdateAsync(_memberWithId100)).ThrowsAsync(new Exception("el registro no fue encontrado")); 
+            var controller = new MemberController(_mock.Object);
+
+            var createdResponse = await controller.Update(_memberWithId100, 100);
+
+            Assert.IsType<BadRequestObjectResult>(createdResponse);
+            var result = createdResponse as BadRequestObjectResult;
+            Assert.NotNull(result);
+            Result response = result.Value as Result;
+            Assert.NotNull(response);
+            var responseMessage = response.Messages[0];
+            Assert.Equal("Ocurrio un error al momento de intentar actulizar los datos - el registro no fue encontrado", responseMessage);
+        }
+
+        [Fact(DisplayName ="Update member with invalid data should return BadRequest")]
+        public async Task UpdateMemberWithInvalidDataShouldReturnBadRequest()
+        {
+            _mock.Setup(m => m.UpdateAsync(_memberWithoutName));
+            var controller = new MemberController(_mock.Object);
+            controller.ModelState.AddModelError("Name","Required");
+
+            var createdResponse = await controller.Update(_memberWithoutName, 1);
+
+            Assert.IsType<BadRequestObjectResult>(createdResponse);
+            var result = createdResponse as BadRequestObjectResult;
+            Assert.NotNull(result);
+            Result response = result.Value as Result;
+            Assert.NotNull(response);
+            var responseMessage = response.Messages[0];
+            Assert.Equal("Algo salio mal.", responseMessage);            
+        }
+    }
+}


### PR DESCRIPTION
1. tests para endpoint createmember creados.
2. tests para endpoint getmembers creados.
3. tests para endpoint updatemember creados.
4. clases auxiliares para dbcontext falso y servicio falso creados.

### Todos los tests pasaron con éxito.
![testing-endpoints-of-member](https://user-images.githubusercontent.com/21247165/148712100-22b30bd0-de76-4460-8060-1efbd82459ee.png)

